### PR TITLE
Fix Warnings; cmake compatible for gcc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,11 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
-set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -g -fstandalone-debug")
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -Wall -g")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
+  add_link_options("-fuse-ld=lld")
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fstandalone-debug")
+endif()
 
 add_executable(${PROJECT_NAME}  ${UTIL_SOURCES} ${MAIN_SOURCES} ${FUNC_SOURCES} ${EVEN_SOURCES})
 

--- a/functions/auto114/auto114.cpp
+++ b/functions/auto114/auto114.cpp
@@ -39,7 +39,7 @@ int auto114::find_min(int64_t input)
 
 std::string auto114::getans(int64_t input)
 {
-    if (1ll << 62 < input || input < -1ll << 62) {
+    if (1ll << 62 < input || input < -1ull << 62) {
         return "No bigInt";
     }
     if (input < 0) {

--- a/functions/cat/cat.cpp
+++ b/functions/cat/cat.cpp
@@ -22,12 +22,7 @@ std::string Cat::generateRandomPattern() { return patterns[get_random(5)]; }
 
 std::string Cat::getLocationString(Place location)
 {
-    if (location >= 4) {
-        return "";
-    }
-    else {
-        return place_to_string[location];
-    }
+    return place_to_string[location];
 }
 
 std::string Cat::get_random_text(const Json::Value &J)

--- a/functions/hhsh/hhsh.cpp
+++ b/functions/hhsh/hhsh.cpp
@@ -42,14 +42,11 @@ void hhsh::process(std::string message, const msg_meta &conf)
             }
             else {
                 res.append(J["name"].asString()).append("有可能是：\n");
-                int t = 0;
                 Json::Value maybe_value = J["inputting"];
                 Json::ArrayIndex msz = maybe_value.size();
                 for (Json::ArrayIndex i = 0; i < msz; i++) {
                     res.append(maybe_value[i].asString());
                     res += ' ';
-                    t++;
-                    // if(t >= 10) break;
                 }
             }
         }
@@ -59,13 +56,13 @@ void hhsh::process(std::string message, const msg_meta &conf)
             }
             else {
                 res.append(J["name"].asString()).append("是：\n");
-                int t = 0;
+                // int t = 0;
                 Json::Value maybe_value = J["trans"];
                 Json::ArrayIndex msz = maybe_value.size();
                 for (Json::ArrayIndex i = 0; i < msz; i++) {
                     res.append(maybe_value[i].asString());
                     res += ' ';
-                    t++;
+                    // t++;
                     // if(t >= 10) break;
                 }
             }

--- a/functions/op_gray/gray_list.cpp
+++ b/functions/op_gray/gray_list.cpp
@@ -31,7 +31,7 @@ void gray_list::process(std::string message, const msg_meta &conf){
         if(res["status"].asString() == "failed"){
             msg_meta s_conf;
             s_conf.group_id = -1;
-            s_conf.message_type == "private";
+            s_conf.message_type = "private";
             s_conf.user_id = conf.user_id;
             cq_send("无法踢出\nmsg: " + res["wording"].asString(), s_conf);
         } else {
@@ -44,7 +44,7 @@ void gray_list::process(std::string message, const msg_meta &conf){
         if(res["status"].asString() == "failed"){
             msg_meta s_conf;
             s_conf.group_id = -1;
-            s_conf.message_type == "private";
+            s_conf.message_type = "private";
             s_conf.user_id = conf.user_id;
             cq_send("将 " + user_name + " 添加进灰名单\nmsg: " + res["wording"].asString(), s_conf);
         }


### PR DESCRIPTION
```bash
/home/yuan/codes/cpp/shinxbot2/functions/auto114/auto114.cpp:42:43: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
    if (1ll << 62 < input || input < -1ll << 62) {
                                     ~~~~ ^
/home/yuan/codes/cpp/shinxbot2/functions/cat/cat.cpp:25:18: warning: result of comparison of constant 4 with expression of type 'Place' is always false [-Wtautological-constant-out-of-range-compare]
    if (location >= 4) {
        ~~~~~~~~ ^  ~
/home/yuan/codes/cpp/shinxbot2/functions/hhsh/hhsh.cpp:45:21: warning: variable 't' set but not used [-Wunused-but-set-variable]
                int t = 0;
                    ^
/home/yuan/codes/cpp/shinxbot2/functions/hhsh/hhsh.cpp:62:21: warning: variable 't' set but not used [-Wunused-but-set-variable]
                int t = 0;
                    ^
/home/yuan/codes/cpp/shinxbot2/functions/op_gray/gray_list.cpp:34:33: warning: equality comparison result unused [-Wunused-comparison]
            s_conf.message_type == "private";
            ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/home/yuan/codes/cpp/shinxbot2/functions/op_gray/gray_list.cpp:34:33: note: use '=' to turn this equality comparison into an assignment
            s_conf.message_type == "private";
                                ^~
                                =
/home/yuan/codes/cpp/shinxbot2/functions/op_gray/gray_list.cpp:47:33: warning: equality comparison result unused [-Wunused-comparison]
            s_conf.message_type == "private";
            ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~
/home/yuan/codes/cpp/shinxbot2/functions/op_gray/gray_list.cpp:47:33: note: use '=' to turn this equality comparison into an assignment
            s_conf.message_type == "private";
                                ^~
                                =
2 warnings generated.
```