### PR TITLE
Move dependencies to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,11 @@
 FROM debian:12
+
+RUN apt-get update && apt-get install -y build-essential wget cmake \
+    libcurl4-openssl-dev openssl libssl-dev libjsoncpp-dev libzip-dev \
+    libjpeg-dev libpng-dev libtiff-dev libgif-dev libwebp-dev webp \ 
+    libmagick++-dev libfmt-dev
+
+RUN wget https://www.imagemagick.org/download/ImageMagick.tar.gz -P /tmp && \
+    cd /tmp && tar -xvf ImageMagick.tar.gz && \
+    cd ImageMagick-* && ./configure && make && make install && \
+    echo "/usr/local/lib/" >> /etc/ld.so.conf && ldconfig

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,17 +1,5 @@
 #!/bin/bash
 
-apt-get update
-apt-get install -y build-essential wget cmake 
-apt-get install -y libcurl4-openssl-dev openssl libssl-dev libjsoncpp-dev libzip-dev
-apt-get install -y libjpeg-dev libpng-dev libtiff-dev libgif-dev libwebp-dev webp libmagick++-dev
-apt-get install -y libfmt-dev
-
-cd /tmp
-wget https://www.imagemagick.org/download/ImageMagick.tar.gz
-tar -xvf ImageMagick.tar.gz
-cd ImageMagick-* && ./configure && make && make install
-echo "/usr/local/lib/" >> /etc/ld.so.conf && ldconfig
-
 cd /workspace
 ./build.sh
 


### PR DESCRIPTION
Moved the `apt-get` part and `ImageMagick` installation (with a little bit of adjustment) to `Dockerfile` because I'd like it not to rerun those snippet and cache them in pre-built images.

Don't merge this now because I'm still fixing some stupid mistakes I got.