### PR TITLE
feat: 使 reply(responder) 功能可以监听新用户入群

### DIFF
--- a/src/functions/memberchangef/m_change_f.cpp
+++ b/src/functions/memberchangef/m_change_f.cpp
@@ -83,10 +83,6 @@ void m_change_f::process(std::string message, const msg_meta &conf)
 
     std::wstring message_w = string_to_wstring(message);
 
-    if (message == "$m_welcome") {
-        return;
-    }
-
     if (conf.message_type == "internal") {
         std::wstring welcome_message = trim(this->format_message(
             this->get_welcome_message(conf.group_id), conf));
@@ -211,10 +207,9 @@ bool m_change_f::check(std::string message, const msg_meta &conf)
 {
     return conf.group_id != 0 &&
            (cmd_match_exact(message, {"welcome.help"}) ||
-            cmd_match_prefix(message, {"设置入群消息", "删除入群消息", "设置入群消息内部触发 开", "设置入群消息内部触发 关"}) ||
+            cmd_match_prefix(message, {"设置入群消息", "删除入群消息"}) ||
             (conf.message_type == "internal" &&
-             conf.message_id == internal_message::kMemberChangeWelcome) ||
-            message == "$m_welcome");
+             conf.message_id == internal_message::kMemberChangeWelcome));
 }
 
 std::string m_change_f::help() { return ""; }

--- a/src/functions/memberchangef/m_change_f.cpp
+++ b/src/functions/memberchangef/m_change_f.cpp
@@ -82,6 +82,11 @@ void m_change_f::process(std::string message, const msg_meta &conf)
     }
 
     std::wstring message_w = string_to_wstring(message);
+
+    if (message == "$m_welcome") {
+        return;
+    }
+
     if (conf.message_type == "internal") {
         std::wstring welcome_message = trim(this->format_message(
             this->get_welcome_message(conf.group_id), conf));
@@ -177,11 +182,28 @@ void m_change_f::flush_welcome_queue(bot *p)
 
     for (const auto &item : pending) {
         msg_meta conf{"group", item.user_id, item.group_id, item.message_id,
-                      item.p != nullptr ? item.p : p};
+                    item.p != nullptr ? item.p : p};
+
+        if (conf.p == nullptr) {
+            continue;
+        }
+
         const std::wstring &welcome_message = item.welcome_message;
-        if (conf.p != nullptr) {
+        if (!welcome_message.empty()) {
             conf.p->cq_send(wstring_to_string(welcome_message), conf);
         }
+
+        Json::Value fake;
+        fake["post_type"] = "message";
+        fake["message_type"] = "group";
+        fake["group_id"] = item.group_id;
+        fake["user_id"] = item.user_id;
+        fake["message"] = "$m_welcome";
+        fake["raw_message"] = "$m_welcome";
+        fake["font"] = 0;
+        fake["sender"] = Json::Value();
+        fake["sender"]["user_id"] = item.user_id;
+        conf.p->input_process(fake.toStyledString());
     }
 }
 
@@ -189,10 +211,12 @@ bool m_change_f::check(std::string message, const msg_meta &conf)
 {
     return conf.group_id != 0 &&
            (cmd_match_exact(message, {"welcome.help"}) ||
-            cmd_match_prefix(message, {"设置入群消息", "删除入群消息"}) ||
+            cmd_match_prefix(message, {"设置入群消息", "删除入群消息", "设置入群消息内部触发 开", "设置入群消息内部触发 关"}) ||
             (conf.message_type == "internal" &&
-             conf.message_id == internal_message::kMemberChangeWelcome));
+             conf.message_id == internal_message::kMemberChangeWelcome) ||
+            message == "$m_welcome");
 }
+
 std::string m_change_f::help() { return ""; }
 
 std::string m_change_f::help(const msg_meta &conf, help_level_t level)

--- a/src/functions/responder/responder.cpp
+++ b/src/functions/responder/responder.cpp
@@ -246,15 +246,9 @@ void Responder::send_reply_by_trigger(groupid_t group_id,
         }
     }
     else {
-        if (conf.message_type == "private") {
-            msg_meta private_conf{"private", conf.user_id, 0, 0, conf.p};
-            conf.p->cq_send(response, private_conf);
-        }
-        else {
-            msg_meta group_conf{"group", conf.user_id, group_id, 0, conf.p};
-            conf.p->cq_send(response, group_conf);
-        }
+        conf.p->cq_send(response, conf);
     }
+    return;
 }
 
 void Responder::save()

--- a/src/functions/responder/responder.cpp
+++ b/src/functions/responder/responder.cpp
@@ -210,14 +210,15 @@ void Responder::process(std::string message, const msg_meta &conf)
     if (groupid == 0) {
         return;
     }
-    send_reply_by_trigger(groupid, conf.user_id, trim(message), conf.p);
+    send_reply_by_trigger(groupid, trim(message), conf);
     return;
 }
 
-void Responder::send_reply_by_trigger(groupid_t group_id, userid_t user_id,
-                                      const std::string &trigger, bot *p)
+void Responder::send_reply_by_trigger(groupid_t group_id,
+                                      const std::string &trigger,
+                                      const msg_meta &conf)
 {
-    if (group_id == 0 || p == nullptr) {
+    if (group_id == 0 || conf.p == nullptr) {
         return;
     }
 
@@ -229,18 +230,30 @@ void Responder::send_reply_by_trigger(groupid_t group_id, userid_t user_id,
     std::string response = it_reply->second;
     size_t pos = 0;
     while ((pos = response.find("{{username}}", pos)) != std::string::npos) {
-        response.replace(pos, 12, get_username(p, user_id, group_id));
+        response.replace(pos, 12, get_username(conf.p, conf.user_id, group_id));
     }
 
     if (response.find("[fwd]") == 0) {
         Json::Value J;
         J["message"] = string_to_json(response.substr(5))["messages"];
-        J["group_id"] = group_id;
-        p->cq_send("send_group_forward_msg", J);
+        if (conf.message_type == "private") {
+            J["user_id"] = conf.user_id;
+            conf.p->cq_send("send_private_forward_msg", J);
+        }
+        else {
+            J["group_id"] = group_id;
+            conf.p->cq_send("send_group_forward_msg", J);
+        }
     }
     else {
-        msg_meta conf{"group", user_id, group_id, 0, p};
-        p->cq_send(response, conf);
+        if (conf.message_type == "private") {
+            msg_meta private_conf{"private", conf.user_id, 0, 0, conf.p};
+            conf.p->cq_send(response, private_conf);
+        }
+        else {
+            msg_meta group_conf{"group", conf.user_id, group_id, 0, conf.p};
+            conf.p->cq_send(response, group_conf);
+        }
     }
 }
 

--- a/src/functions/responder/responder.cpp
+++ b/src/functions/responder/responder.cpp
@@ -10,6 +10,7 @@ static std::string HELP =
     "变量。（response可以在第二条消息中发出）\n"
     "reply.del [trigger]\n"
     "reply.del [group_id] [trigger]\n"
+    "若为特殊触发词 $m_welcome 设置了内容, 这个触发词将在有新人入群时自动触发\n"
     "只能由群管理员操作。";
 void Responder::process(std::string message, const msg_meta &conf)
 {
@@ -209,34 +210,38 @@ void Responder::process(std::string message, const msg_meta &conf)
     if (groupid == 0) {
         return;
     }
-    auto it_reply = replies[groupid].find(trim(message));
-    if (it_reply != replies[groupid].end()) {
-        std::string response = it_reply->second;
-        size_t pos = 0;
-        while ((pos = response.find("{{username}}", pos)) !=
-               std::string::npos) {
-            response.replace(pos, 12,
-                             get_username(conf.p, conf.user_id, groupid));
-        }
-        if (response.find("[fwd]") == 0) {
-            if (conf.message_type == "private") {
-                Json::Value J;
-                J["message"] = string_to_json(response.substr(5))["messages"];
-                J["user_id"] = conf.user_id;
-                conf.p->cq_send("send_private_forward_msg", J);
-            }
-            else {
-                Json::Value J;
-                J["message"] = string_to_json(response.substr(5))["messages"];
-                J["group_id"] = conf.group_id;
-                conf.p->cq_send("send_group_forward_msg", J);
-            }
-        }
-        else {
-            conf.p->cq_send(response, conf);
-        }
-    }
+    send_reply_by_trigger(groupid, conf.user_id, trim(message), conf.p);
     return;
+}
+
+void Responder::send_reply_by_trigger(groupid_t group_id, userid_t user_id,
+                                      const std::string &trigger, bot *p)
+{
+    if (group_id == 0 || p == nullptr) {
+        return;
+    }
+
+    auto it_reply = replies[group_id].find(trim(trigger));
+    if (it_reply == replies[group_id].end()) {
+        return;
+    }
+
+    std::string response = it_reply->second;
+    size_t pos = 0;
+    while ((pos = response.find("{{username}}", pos)) != std::string::npos) {
+        response.replace(pos, 12, get_username(p, user_id, group_id));
+    }
+
+    if (response.find("[fwd]") == 0) {
+        Json::Value J;
+        J["message"] = string_to_json(response.substr(5))["messages"];
+        J["group_id"] = group_id;
+        p->cq_send("send_group_forward_msg", J);
+    }
+    else {
+        msg_meta conf{"group", user_id, group_id, 0, p};
+        p->cq_send(response, conf);
+    }
 }
 
 void Responder::save()

--- a/src/functions/responder/responder.h
+++ b/src/functions/responder/responder.h
@@ -16,6 +16,8 @@ private:
     void save();
     std::string get_reply_message(const std::string &message,
                                   const msg_meta &conf);
+    void send_reply_by_trigger(groupid_t group_id, userid_t user_id,
+                               const std::string &trigger, bot *p);
 
 public:
     Responder();

--- a/src/functions/responder/responder.h
+++ b/src/functions/responder/responder.h
@@ -16,8 +16,8 @@ private:
     void save();
     std::string get_reply_message(const std::string &message,
                                   const msg_meta &conf);
-    void send_reply_by_trigger(groupid_t group_id, userid_t user_id,
-                               const std::string &trigger, bot *p);
+    void send_reply_by_trigger(groupid_t group_id, const std::string &trigger,
+                              const msg_meta &conf);
 
 public:
     Responder();


### PR DESCRIPTION
为了防止 m_change_f 模块提供的入群欢迎消息刷屏, 我向支持合并转发的 reply(responder) 功能加入了监听新用户入群并自动发送欢迎的功能

现在可以使用 "reply.add $m_welcome" 命令加入一条 reply 消息, 这个消息将在入群欢迎消息发送完后自动发送