### PR TITLE
perf(http): truncate proxy string in place instead of substr self-assign

### DIFF
--- a/src/utils/HTTP_connect.cpp
+++ b/src/utils/HTTP_connect.cpp
@@ -84,7 +84,7 @@ std::string do_http_request(httplib::Client &client,
 
                 const size_t slash_pos = proxy_str.find('/');
                 if (slash_pos != std::string::npos) {
-                    proxy_str = proxy_str.substr(0, slash_pos);
+                    proxy_str.erase(slash_pos); // truncate in place
                 }
 
                 const size_t at_pos = proxy_str.rfind('@');


### PR DESCRIPTION
`proxy_str = proxy_str.substr(0, slash_pos)` reallocates a new string just to drop a suffix; `proxy_str.erase(slash_pos)` truncates in place. Flagged by cppcheck (`uselessCallsSubstr`). No behavior change.

Co-authored with Claude Code.